### PR TITLE
support new levelup encoding pattern

### DIFF
--- a/bytewise.js
+++ b/bytewise.js
@@ -382,13 +382,3 @@ exports.decode = decode;
 exports.compare = compare;
 exports.buffer = true
 exports.type = 'bytewise'
-
-exports.hex = {
-  encode: function (val) {
-    return bops.to(encode(val), 'hex')
-  },
-  decode: function (val) {
-    return decode(bops.from(val, 'hex'))
-  },
-  buffer: false, type: 'bytewise-hex'
-}

--- a/hex.js
+++ b/hex.js
@@ -1,0 +1,10 @@
+var bops = require('bops')
+var bytewise = require('./')
+exports.encode = function (val) {
+  return bops.to(bytewise.encode(val), 'hex')
+}
+exports.decode = function (val) {
+  return bytewise.decode(bops.from(val, 'hex'))
+}
+exports.buffer = false
+exports.type = 'bytewise-hex'

--- a/test/order.js
+++ b/test/order.js
@@ -1,5 +1,6 @@
 
 var bytewise = require('../')
+var bytewiseHex = require('../hex')
 var typewise = require('typewise')
 var test = require('tap').test
 var bops = require('bops')
@@ -32,9 +33,9 @@ test('sorts with same order when hex encoded', function (t) {
 
   var sorted = 
   example
-    .map(bytewise.hex.encode)
+    .map(bytewiseHex.encode)
     .sort()
-    .map(bytewise.hex.decode)
+    .map(bytewiseHex.decode)
 
   t.deepEqual(sorted, example)
   t.end()


### PR DESCRIPTION
in the next release, levelup will support custom encodings.

https://github.com/rvagg/node-levelup/pull/149

this pull request means that bytewise can be dropped in to an encoding field as a custom encoding.

``` js
levelup(path, {keyEncoding: require('bytewise'), valueEncoding: 'binary'})
```

The important addition is `buffer: true` which tells levelup to retrive a binary value when doing a read to a custom encoded field.

Also, I've added `bytewise-hex` encoding:

``` js
levelup(path, {keyEncoding: require('bytewise/hex'), valueEncoding: 'binary'})
```

this is only a few extra lines, but if you need a string, then you need hex.
(base64 is not useful, because order is not consistent)

Currently, this is needed for sublevel - however, soon I will refactor sublevel to support binary keyEncodings.
